### PR TITLE
[IN:60801] fixed warning with PHP 7: "A non-numeric value encountered…

### DIFF
--- a/runtime/lib/parser/yaml/sfYamlInline.php
+++ b/runtime/lib/parser/yaml/sfYamlInline.php
@@ -127,7 +127,7 @@ class sfYamlInline
     if (
       (1 == count($keys) && '0' == $keys[0])
       ||
-      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
+      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + (integer) $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
     {
       $output = array();
       foreach ($value as $val) {


### PR DESCRIPTION
… in sfYamlInline.php"

propelorm#1070